### PR TITLE
Fix new GNU social and DBMS incompatibilies

### DIFF
--- a/StaleAccountsPlugin.php
+++ b/StaleAccountsPlugin.php
@@ -1,40 +1,51 @@
 <?php
 
-if (!defined('GNUSOCIAL')) {
-    exit(1);
-}
+defined('GNUSOCIAL') || die();
 
 class StaleAccountsPlugin extends Plugin
 {
     const VERSION = '0.0.2';
 
-    function onRouterInitialized($m)
+    public function onRouterInitialized(URLMapper $m): bool
     {
-        $m->connect('panel/staleaccounts', array('action' => 'staleaccountsadminpanel'));
+        $m->connect(
+            'panel/staleaccounts',
+            ['action' => 'staleaccountsadminpanel']
+        );
 
-        $m->connect(':nickname/stalereminder',
-                    array('action' => 'stalereminder'),
-                    array('nickname' => Nickname::DISPLAY_FMT));
+        $m->connect(
+            ':nickname/stalereminder',
+            ['action' => 'stalereminder'],
+            ['nickname' => Nickname::DISPLAY_FMT]
+        );
 
         return true;
     }
 
-    function onEndAdminPanelNav($nav) {
+    public function onEndAdminPanelNav(AdminPanelNav $nav): bool
+    {
         if (AdminPanelAction::canAdmin('user')) {
-            $menu_title = _('Stale accounts management');
+            $menu_title  = _('Stale accounts management');
             $action_name = $nav->action->trimmed('action');
 
-            $nav->out->menuItem(common_local_url('staleaccountsadminpanel'), _m('MENU','Stale Accounts'),
-                                 $menu_title, $action_name == 'staleaccountsadminpanel', 'stale_accounts_admin_panel');
+            $nav->out->menuItem(
+                common_local_url('staleaccountsadminpanel'),
+                _m('MENU', 'Stale Accounts'),
+                $menu_title,
+                ($action_name === 'staleaccountsadminpanel'),
+                'stale_accounts_admin_panel'
+            );
         }
+
+        return true;
     }
 
     /**
      * If the plugin's installed, this should be accessible to admins
      */
-    function onAdminPanelCheck($name, &$isOK)
+    public function onAdminPanelCheck(string $name, bool &$isOK): bool
     {
-        if ($name == 'staleaccounts') {
+        if ($name === 'staleaccounts') {
             $isOK = true;
             return false;
         }
@@ -42,23 +53,23 @@ class StaleAccountsPlugin extends Plugin
         return true;
     }
 
-    function onEndShowStyles($action)
+    public function onEndShowStyles(Action $action): bool
     {
         $action->cssLink($this->path('css/stale-accounts.css'));
 
         return true;
     }
 
-    function onPluginVersion(array &$versions)
+    public function onPluginVersion(array &$versions): bool
     {
-        $versions[] = array('name' => 'Stale Accounts',
-                            'version' => self::VERSION,
-                            'author' => 'chimo',
-                            'homepage' => 'https://github.com/chimo/gs-staleAccounts',
-                            'description' =>
-                            // TRANS: Plugin description.
-                            _m('')); // TODO
+        $versions[] = [
+            'name'        => 'Stale Accounts',
+            'version'     => self::VERSION,
+            'author'      => 'chimo',
+            'homepage'    => 'https://github.com/chimo/gs-staleAccounts',
+            // TRANS: Plugin description.
+            'description' => _m(''), // TODO
+        ];
         return true;
     }
 }
-

--- a/actions/staleaccountsadminpanel.php
+++ b/actions/staleaccountsadminpanel.php
@@ -1,15 +1,16 @@
 <?php
-if (!defined('GNUSOCIAL')) {
-    exit(1);
-}
+
+defined('GNUSOCIAL') || die();
 
 class StaleaccountsadminpanelAction extends AdminPanelAction
 {
-    function title() {
+    public function title(): string
+    {
         return 'Stale accounts';
     }
 
-    function prepare(array $args=array()) {
+    public function prepare(array $args = []): bool
+    {
         parent::prepare($args);
 
         $this->page = $this->int('page', 1, null, 1);
@@ -18,7 +19,8 @@ class StaleaccountsadminpanelAction extends AdminPanelAction
         return true;
     }
 
-    function showContent() {
+    public function showContent(): void
+    {
         $properties = [
             'id',
             'nickname',
@@ -37,7 +39,8 @@ class StaleaccountsadminpanelAction extends AdminPanelAction
 
         $inactive_period = common_config('staleaccounts', 'inactive_period');
 
-        if ($inactive_period === false) { // No config set fallback to default
+        // No config set fallback to default
+        if ($inactive_period === false) {
             $inactive_period = 3;
         } else {
             // Make sure config is a number
@@ -77,18 +80,20 @@ class StaleaccountsadminpanelAction extends AdminPanelAction
         $cnt = $dataObj->N;
 
         if ($cnt === 0) {
-            $this->element('p', null,
-                'No accounts have been inactive for more than ' . $inactive_period . ' months.');
-
-            return true;
+            $this->element(
+                'p',
+                null,
+                "No accounts have been inactive for more than {$inactive_period} months."
+            );
+            return;
         }
 
         $this->elementStart('ul', array('class' => 'stale_profile_list'));
 
-        while($dataObj->fetch()) {
+        while ($dataObj->fetch()) {
             $profile = new Profile();
 
-            foreach($properties as $property) {
+            foreach ($properties as $property) {
                 $profile->$property = $dataObj->$property;
             }
 
@@ -109,25 +114,34 @@ class StaleaccountsadminpanelAction extends AdminPanelAction
         );
     }
 
-    function showNoticeForm() {
+    public function showNoticeForm(): void
+    {
         // Don't generate a notice form
     }
 
-    function showProfileBlock() {
+    public function showProfileBlock(): void
+    {
         // Don't generate a profile block
     }
 }
 
-class StaleProfileListItem extends ProfileListItem {
-    function showBio() {
+class StaleProfileListItem extends ProfileListItem
+{
+    public function showBio(): void
+    {
         parent::showBio();
 
         $latest_activity = $this->profile->latest_activity ?: 'NEVER';
 
-        $this->action->element('p', array('class' => 'note'), 'Latest activity: ' . $latest_activity);
+        $this->action->element(
+            'p',
+            ['class' => 'note'],
+            'Latest activity: ' . $latest_activity
+        );
     }
 
-    function showActions() {
+    public function showActions(): void
+    {
         parent::startActions();
 
         try {
@@ -141,11 +155,13 @@ class StaleProfileListItem extends ProfileListItem {
                 $form->show();
                 $this->action->elementEnd('li');
             } else {
-                $this->action->element('li', array('class' => 'unconfirmed_email'),
-                    'unconfirmed email' . $user->email);
-        }
-
-        } catch(Exception $e) {
+                $this->action->element(
+                    'li',
+                    ['class' => 'unconfirmed_email'],
+                    'unconfirmed email' . $user->email
+                );
+            }
+        } catch (Exception $e) {
             // This shouldn't be possible -- famous last words
             common_log(LOG_ERR, $e->getMessage());
         }
@@ -170,43 +186,49 @@ class StaleProfileListItem extends ProfileListItem {
  * I haven't found a way to use the "current theme's sprite file" from
  * the plugin's stylesheet.
  */
-class StaleReminderForm extends Form {
-    var $profile = null;
+class StaleReminderForm extends Form
+{
+    public $profile = null;
 
-    function __construct($out=null, $profile=null)
+    public function __construct($out = null, $profile = null)
     {
         parent::__construct($out);
         $this->profile = $profile;
     }
 
-    function id()
+    public function id(): ?string
     {
         return 'form_user_nudge';
     }
 
-    function formClass()
+    public function formClass(): string
     {
         return 'form_user_nudge ajax';
     }
 
-    function action()
+    public function action(): ?string
     {
-        return common_local_url('stalereminder', array('nickname' => $this->profile->nickname));
+        return common_local_url(
+            'stalereminder',
+            ['nickname' => $this->profile->nickname]
+        );
     }
 
-    function formLegend()
+    public function formLegend(): void
     {
         $this->out->element('legend', null, _('Remind this user'));
     }
 
-    function formActions()
+    public function formActions(): void
     {
-        $this->out->submit('submit',
-                           // TRANS: Button text to reminder/ping another user.
-                           _m('BUTTON','Remind'),
-                           'submit',
-                           null,
-                           // TRANS: Button title to reminder/ping another user.
-                           _('Send a reminder to this user.'));
+        $this->out->submit(
+            'submit',
+            // TRANS: Button text to reminder/ping another user.
+            _m('BUTTON', 'Remind'),
+            'submit',
+            null,
+            // TRANS: Button title to reminder/ping another user.
+            _('Send a reminder to this user.')
+        );
     }
 }

--- a/actions/stalereminder.php
+++ b/actions/stalereminder.php
@@ -1,15 +1,12 @@
 <?php
 
-if (!defined('GNUSOCIAL')) {
-    exit(1);
-}
+defined('GNUSOCIAL') || die();
 
-require_once INSTALLDIR.'/lib/mail.php';
+require_once INSTALLDIR . '/lib/mail.php';
 
 class StaleReminderAction extends Action
 {
-
-    function handle()
+    public function handle(): void
     {
         parent::handle();
 
@@ -20,9 +17,11 @@ class StaleReminderAction extends Action
         $user  = common_current_user();
         $other = User::getKV('nickname', $this->arg('nickname'));
 
-        if ($_SERVER['REQUEST_METHOD'] != 'POST') {
-            common_redirect(common_local_url('showstream',
-                array('nickname' => $other->nickname)));
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            common_redirect(common_local_url(
+                'showstream',
+                ['nickname' => $other->nickname]
+            ));
         }
 
         // CSRF protection
@@ -53,23 +52,27 @@ class StaleReminderAction extends Action
             $this->endHTML();
         } else {
             // display a confirmation to the user
-            common_redirect(common_local_url('showstream',
-                                             array('nickname' => $other->nickname)),
-                            303);
+            common_redirect(
+                common_local_url(
+                    'showstream',
+                    ['nickname' => $other->nickname]
+                ),
+                303
+            );
         }
     }
 
-     /**
-     * Do the actual notification
-     *
-     * @param class $from reminderer
-     * @param class $to reminderee
-     *
-     * @return nothing
-     */
-    function notify($from, $to)
+    /**
+    * Do the actual notification
+    *
+    * @param class $from reminderer
+    * @param class $to reminderee
+    *
+    * @return nothing
+    */
+    private function notify(string $from, string $to): void
     {
-        if ($to->id != $from->id) {
+        if ($to->id !== $from->id) {
             if ($to->email) {
                 // TODO
                 common_switch_locale($to->language);
@@ -82,18 +85,23 @@ class StaleReminderAction extends Action
                 // TRANS: Body for 'reminder' notification email.
                 // TRANS: %1$s is the sender's long name, $2$s is the receiver's nickname,
                 // TRANS: %3$s is a URL to post notices at.
-                $body = sprintf(_("%1\$s (%2\$s) is wondering what you are up to ".
-                                  "these days and is inviting you to post some news.\n\n".
-                                  "So let's hear from you :)\n\n".
-                                  "%3\$s\n\n".
-                                  "Don't reply to this email; it won't get to them."),
-                                $from_profile->getBestName(),
-                                $from->nickname,
-                                common_local_url('all', array('nickname' => $to->nickname))) .
-                        mail_footer_block();
+                $body = sprintf(
+                    _("%1\$s (%2\$s) is wondering what you are up to ".
+                      "these days and is inviting you to post some news.\n\n".
+                      "So let's hear from you :)\n\n".
+                      "%3\$s\n\n".
+                      "Don't reply to this email; it won't get to them."),
+                    $from_profile->getBestName(),
+                    $from->nickname,
+                    common_local_url('all', array('nickname' => $to->nickname))
+                ) . mail_footer_block();
                 common_switch_locale();
 
-                $headers = $this->mail_prepare_headers('nudge', $to->nickname, $from->nickname);
+                $headers = $this->mailPrepareHeaders(
+                    'nudge',
+                    $to->nickname,
+                    $from->nickname
+                );
 
                 return mail_to_user($to, $subject, $body, $headers);
             }
@@ -109,18 +117,21 @@ class StaleReminderAction extends Action
      *
      * @return array list of mail headers to include in the message
      */
-    function mail_prepare_headers($msg_type, $to, $from)
-    {
-        $headers = array(
+    private function mailPrepareHeaders(
+        string $msg_type,
+        string $to,
+        string $from
+    ): array {
+        $headers = [
             'X-GNUsocial-MessageType' => $msg_type,
             'X-GNUsocial-TargetUser'  => $to,
             'X-GNUsocial-SourceUser'  => $from,
             'X-GNUsocial-Domain'      => common_config('site', 'server')
-        );
+        ];
         return $headers;
     }
 
-    function isReadOnly($args)
+    public function isReadOnly($args): bool
     {
         return true;
     }


### PR DESCRIPTION
Add type declarations everywhere to avoid incompatibilies with parent methods when they obtain those (currently only "prepare" actually needs that). This raises the PHP requirement to 7.1.

Alter the query to make it work on PostgreSQL and on MariaDB/MySQL with ONLY_FULL_GROUP_BY.

And re-format the code using php-cs-fixer.